### PR TITLE
feat: Allow specifying a minimum change size for incurring a red mark

### DIFF
--- a/change/@ardiffact-bundle-size-report-1100670e-7417-44bf-a27a-83e1fa902cb3.json
+++ b/change/@ardiffact-bundle-size-report-1100670e-7417-44bf-a27a-83e1fa902cb3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow specifying a minimum change size for incurring a red mark",
+  "packageName": "@ardiffact/bundle-size-report",
+  "email": "asgramme@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/bundle-size-report/src/composeReport.ts
+++ b/packages/bundle-size-report/src/composeReport.ts
@@ -7,13 +7,13 @@ import { createReportData } from "./createReportData";
  * @param bundleStatsResults - Diff results created by {@link @ardiffact/bundle-size-differ#FileDiffResults} object
  * @returns markdown report
  */
-export function createReport(bundleStatsResults: FileDiffResults): string {
+export function createReport(bundleStatsResults: FileDiffResults, minimumIncrease: number = 0): string {
   return ["## Bundle size report"]
-    .concat(createTheReports(bundleStatsResults))
+      .concat(createTheReports(bundleStatsResults, minimumIncrease))
     .join("\n\n");
 }
 
-const createTheReports = (bundleStatsResults: FileDiffResults): string[] => {
+const createTheReports = (bundleStatsResults: FileDiffResults, minimumIncrease: number): string[] => {
   const reportDataWithDifference = bundleStatsResults.withDifferences.map(
     createReportData
   );
@@ -22,7 +22,7 @@ const createTheReports = (bundleStatsResults: FileDiffResults): string[] => {
   const withDifferences: string[] = [
     ...reportDataWithDifference.filter((row) => row.totalDiff !== 0),
     ...reportDataNewFiles.filter((row) => row.totalDiff !== 0),
-  ].map(createDetailedReport);
+  ].map(data => createDetailedReport(data, minimumIncrease));
 
   const withoutDifference: string = createNoChangeReport([
     ...reportDataWithDifference.filter((row) => row.totalDiff === 0),

--- a/packages/bundle-size-report/src/createReport.ts
+++ b/packages/bundle-size-report/src/createReport.ts
@@ -53,14 +53,20 @@ const getDiff = (reportAssetData: ReportAssetData) => {
   return `<span style="${noWrapStyle}">${formattedDiff}</span>`;
 };
 
-const getPercentageAndIcon = (reportAssetData: ReportAssetData) => {
+const getPercentageAndIcon = (
+  reportAssetData: ReportAssetData,
+  minimumIncrease: number
+) => {
   const percentage = getPercentage(reportAssetData);
-  const icon = getEmoji(reportAssetData);
+  const icon = getEmoji(reportAssetData, minimumIncrease);
 
   return `<span style="${noWrapStyle}">${percentage} ${icon}</span>`;
 };
 
-export function createDetailedReport(reportData: ReportData): string {
+export function createDetailedReport(
+  reportData: ReportData,
+  minimumIncrease: number
+): string {
   if (reportData.totalDiff === 0) {
     return "";
   }
@@ -69,7 +75,8 @@ export function createDetailedReport(reportData: ReportData): string {
     ? `<a target="_blank" rel="noopener noreferrer" href="${reportData.comparisonToolUrl}">🔍</a>`
     : "";
   const deltaSizeMessage = `${getReducedOrIncreased(
-    reportData.totalDiff
+    reportData.totalDiff,
+    minimumIncrease
   )} total size by ${formatBytes(Math.abs(reportData.totalDiff))}`;
   const totalSizeMessage = `Total size: ${formatBytes(reportData.totalSize)}`;
   const prefix = `<summary><span style="font-size: 16px">${reportData.name} ${comparisonLink}</span><br><ul><li>${deltaSizeMessage}</li><li>${totalSizeMessage}</li></summary>`;
@@ -81,7 +88,7 @@ export function createDetailedReport(reportData: ReportData): string {
     const fileName = getFileName(reportAssetData);
     const size = getSize(reportAssetData);
     const diff = getDiff(reportAssetData);
-    const percentage = getPercentageAndIcon(reportAssetData);
+    const percentage = getPercentageAndIcon(reportAssetData, minimumIncrease);
 
     return `| ${fileName} | ${size} | ${diff} | ${percentage} |`;
   });
@@ -119,8 +126,13 @@ export function createNoChangeReport(reportData: ReportData[]): string {
   )}\n</details>`;
 }
 
-function getReducedOrIncreased(diffSize: number): string {
-  return diffSize > 0 ? "🔺 Increased" : "✅ Reduced";
+function getReducedOrIncreased(
+  diffSize: number,
+  minimumIncrease: number
+): string {
+  return diffSize > 0
+    ? (diffSize > minimumIncrease ? "🔺&nbsp;" : "") + "Increased"
+    : "✅&nbsp;Reduced";
 }
 
 function formatBytes(bytes: number, decimals: number = 2): string {
@@ -131,9 +143,12 @@ function formatBytes(bytes: number, decimals: number = 2): string {
   return inKb.toFixed(decimals) + " KB";
 }
 
-function getEmoji(reportAssetData: ReportAssetData): string {
+function getEmoji(
+  reportAssetData: ReportAssetData,
+  minimumIncrease: number
+): string {
   if (reportAssetData.isRemoved || reportAssetData.isAdded) {
     return "";
   }
-  return reportAssetData.isReduction ? "✅" : "🔺";
+  return reportAssetData.diff > minimumIncrease ? "✅" : "🔺";
 }

--- a/packages/bundle-size-report/src/createReport.ts
+++ b/packages/bundle-size-report/src/createReport.ts
@@ -150,5 +150,5 @@ function getEmoji(
   if (reportAssetData.isRemoved || reportAssetData.isAdded) {
     return "";
   }
-  return reportAssetData.diff > minimumIncrease ? "✅" : "🔺";
+  return reportAssetData.diff > minimumIncrease ? "🔺" : "✅";
 }


### PR DESCRIPTION
There is often some size jitter when builds aren't perfectly
reproducible. In large reports, this generates a lot of visual noise. In
order to avoid numbing users to negative marks, we now allow callers to
specify a minimum size increase required to trigger the red increase
icon.

The default behavior remains unchanged.